### PR TITLE
Don't show profile pics until deprecated library is replaced

### DIFF
--- a/app/views/companies/show.html.haml
+++ b/app/views/companies/show.html.haml
@@ -2,7 +2,7 @@
 .container
   .profile--header
     .info--logo
-      = image_tag @company.logo.url(:thumb)
+      = image_tag('http://emilychen.co/images/default.jpg')
     .info--company
       %h1
         = @company.name

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -2,7 +2,7 @@
 .container
   .content--center--large
     .profile--left
-      =image_tag @user.profile_pic.url(:thumb)
+      =image_tag('http://emilychen.co/images/default_profile.jpg'))
       %h1= @user.name
       = link_to 'Edit Details', edit_user_path(@user)
       %p.trigger--password Change Password


### PR DESCRIPTION
App uses a deprecated gem. Hiding profile pics until I have time to update the dependency.